### PR TITLE
改进ResourcepackRCE Patch

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/network/MixinNetHandlerPlayClient.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/network/MixinNetHandlerPlayClient.java
@@ -35,6 +35,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -66,13 +67,22 @@ public abstract class MixinNetHandlerPlayClient {
             final String scheme = new URI(url).getScheme();
             final boolean isLevelProtocol = "level".equals(scheme);
 
-            if(!"http".equals(scheme) && !"https".equals(scheme) && !isLevelProtocol)
+            if (!"http".equals(scheme) && !"https".equals(scheme) && !isLevelProtocol)
                 throw new URISyntaxException(url, "Wrong protocol");
 
-            if(isLevelProtocol && (url.contains("..") || !url.endsWith("/resources.zip")))
+            if (isLevelProtocol && (url.contains("..") || !url.endsWith("/resources.zip")))
                 throw new URISyntaxException(url, "Invalid levelstorage resourcepack path");
-        } catch(final URISyntaxException e) {
+        } catch (final URISyntaxException e) {
             ClientUtils.INSTANCE.logError("Failed to handle resource pack", e);
+
+            // ensure it performed like vanilla
+            String s2 = url.substring("level://".length());
+            File file1 = new File(this.gameController.mcDataDir, "saves");
+            File file2 = new File(file1, s2);
+            if(file2.isFile()) {
+                netManager.sendPacket(new C19PacketResourcePackStatus(hash, C19PacketResourcePackStatus.Action.ACCEPTED));
+            }
+            
             netManager.sendPacket(new C19PacketResourcePackStatus(hash, C19PacketResourcePackStatus.Action.FAILED_DOWNLOAD));
             callbackInfo.cancel();
         }
@@ -80,7 +90,7 @@ public abstract class MixinNetHandlerPlayClient {
 
     @Inject(method = "handleJoinGame", at = @At("HEAD"), cancellable = true)
     private void handleJoinGameWithAntiForge(S01PacketJoinGame packetIn, final CallbackInfo callbackInfo) {
-        if(!AntiForge.INSTANCE.getEnabled() || !AntiForge.INSTANCE.getBlockFML() || Minecraft.getMinecraft().isIntegratedServerRunning())
+        if (!AntiForge.INSTANCE.getEnabled() || !AntiForge.INSTANCE.getBlockFML() || Minecraft.getMinecraft().isIntegratedServerRunning())
             return;
 
         PacketThreadUtil.checkThreadAndEnqueue(packetIn, (NetHandlerPlayClient) (Object) this, gameController);
@@ -114,7 +124,7 @@ public abstract class MixinNetHandlerPlayClient {
                 this.gameController.thePlayer.motionZ + packetIn.func_149147_e());
         PacketEvent packetEvent = new PacketEvent(packet, PacketEvent.Type.RECEIVE);
         LiquidBounce.eventManager.callEvent(packetEvent);
-        if(!packetEvent.isCancelled()){
+        if (!packetEvent.isCancelled()) {
             handleEntityVelocity(packet);
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/network/MixinNetHandlerPlayClient.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/network/MixinNetHandlerPlayClient.java
@@ -76,13 +76,15 @@ public abstract class MixinNetHandlerPlayClient {
             ClientUtils.INSTANCE.logError("Failed to handle resource pack", e);
 
             // ensure it performed like vanilla
-            String s2 = url.substring("level://".length());
-            File file1 = new File(this.gameController.mcDataDir, "saves");
-            File file2 = new File(file1, s2);
-            if(file2.isFile()) {
-                netManager.sendPacket(new C19PacketResourcePackStatus(hash, C19PacketResourcePackStatus.Action.ACCEPTED));
+            if(url.startsWith("level://")) {
+                String s2 = url.substring("level://".length());
+                File file1 = new File(this.gameController.mcDataDir, "saves");
+                File file2 = new File(file1, s2);
+                if (file2.isFile()) {
+                    netManager.sendPacket(new C19PacketResourcePackStatus(hash, C19PacketResourcePackStatus.Action.ACCEPTED));
+                }
             }
-            
+
             netManager.sendPacket(new C19PacketResourcePackStatus(hash, C19PacketResourcePackStatus.Action.FAILED_DOWNLOAD));
             callbackInfo.cancel();
         }


### PR DESCRIPTION
让ResourcePack RCE的Patch表现的更像原版客户端，原版客户端会在判断资源包文件是否存在之前发一个Accept

这样可以阻止某些服务器检测该patch, 未测试, 应该就是这样的原理

```java
if (s.startsWith("level://")) {
            String s2 = s.substring("level://".length());
            File file1 = new File(this.gameController.mcDataDir, "saves");
            File file2 = new File(file1, s2);
            if (file2.isFile()) {
                this.netManager.sendPacket(new C19PacketResourcePackStatus(s1, net.minecraft.network.play.client.C19PacketResourcePackStatus.Action.ACCEPTED));
                Futures.addCallback(this.gameController.getResourcePackRepository().setResourcePackInstance(file2), new FutureCallback<Object>() {
                    public void onSuccess(Object p_onSuccess_1_) {
                        NetHandlerPlayClient.this.netManager.sendPacket(new C19PacketResourcePackStatus(s1, net.minecraft.network.play.client.C19PacketResourcePackStatus.Action.SUCCESSFULLY_LOADED));
                    }

                    public void onFailure(Throwable p_onFailure_1_) {
                        NetHandlerPlayClient.this.netManager.sendPacket(new C19PacketResourcePackStatus(s1, net.minecraft.network.play.client.C19PacketResourcePackStatus.Action.FAILED_DOWNLOAD));
                    }
                });
            } else {
                this.netManager.sendPacket(new C19PacketResourcePackStatus(s1, net.minecraft.network.play.client.C19PacketResourcePackStatus.Action.FAILED_DOWNLOAD));
            }
        }
        
 ```